### PR TITLE
Fix CartRuleRestrictionGroupItem documentation

### DIFF
--- a/docs/CartRuleRestrictionGroupItem.md
+++ b/docs/CartRuleRestrictionGroupItem.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**type** | **String** | Can be: product, subscription, category, actor or director | [optional] 
+**type** | **String** | Can be: products, subscriptions, categories, actors or directors | [optional] 
 **idItem** | **Integer** | Item ID to restrict | [optional] 
 
 


### PR DESCRIPTION
Type should be products, categories… instead of product, category… to
avoid following error:

```
{
  errors: {
    'restriction_groups.0.items.0.type': [ 'The selected restriction_groups.0.items.0.type is invalid.' ]
  },
  statusCode: 400
}
```